### PR TITLE
Improve the loading of a textdomain.

### DIFF
--- a/portfolio-post-type.php
+++ b/portfolio-post-type.php
@@ -65,7 +65,7 @@ class Portfolio_Post_Type {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
+		load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/languages' );
 	}
 
 	/**


### PR DESCRIPTION
By moving the loading of a text domain into a method, we can expand it a bit to look in the WP_LANG_DIR first for a set of translation files (this is where developers should put their own translation files, if they don't want them wiped out during a plugin update) before falling back to looking in the plugin /languages directory.

I've also included a call to this textdomain loading method within the plugin activation method, to try and ensure that strings are translatable during activation too, and not just on subsequent page reloads.
