### PR TITLE
Add Portfolio Icon to WordPress 3.8

### DIFF
--- a/includes/class-portfolio-post-type-admin.php
+++ b/includes/class-portfolio-post-type-admin.php
@@ -243,6 +243,12 @@ class Portfolio_Post_Type_Admin {
 			#icon-edit.icon32-posts-<?php echo $this->registration_handler->post_type; ?> {
 				background: url(<?php echo $plugin_dir_url; ?>images/portfolio-32x32.png) no-repeat;
 			}
+			#menu-posts-portfolio .wp-menu-image.dashicons {
+				background: url() !important;
+			}
+			#menu-posts-portfolio .wp-menu-image img {
+				display: none;
+			}
 		</style>
 		<?php
 	}

--- a/includes/class-portfolio-post-type-registrations.php
+++ b/includes/class-portfolio-post-type-registrations.php
@@ -82,6 +82,7 @@ class Portfolio_Post_Type_Registrations {
 			'capability_type' => 'post',
 			'rewrite'         => array( 'slug' => 'portfolio', ), // Permalinks format
 			'menu_position'   => 5,
+			'menu_icon'       => 'dashicons-portfolio',
 			'has_archive'     => true,
 		);
 


### PR DESCRIPTION
This solution adds the the `dashicon-portfolio` class to the `menu_icon` like explained in [WordPress core](https://github.com/WordPress/WordPress/blob/master/wp-includes/post.php#L1134)

The first css removes the background image link if it has the class `dashicons` and hides the invalid image in the older versions of WordPress.
`<img src="http://dashicons-portfolio" alt="">`
