### PR TITLE
Fix when no terms from an associated taxonomy are selected. See #36.

### DIFF
--- a/includes/class-gamajo-single-entry-term-body-classes.php
+++ b/includes/class-gamajo-single-entry-term-body-classes.php
@@ -74,11 +74,8 @@ class Gamajo_Single_Entry_Term_Body_Classes {
 	protected function get_taxonomy_term_classes( $taxonomies ) {
 		$classes = array();
 		foreach ( (array) $taxonomies as $taxonomy ) {
-			$terms = $this->get_terms( $taxonomy );
-			if ( is_array( $terms ) ) {
-				foreach (  $terms as $term ) {
-					$classes[] = $this->get_taxonomy_term_class( $taxonomy, $term->slug );
-				}
+			foreach ( $this->get_terms( $taxonomy ) as $term ) {
+				$classes[] = $this->get_taxonomy_term_class( $taxonomy, $term->slug );
 			}
 		}
 
@@ -104,7 +101,7 @@ class Gamajo_Single_Entry_Term_Body_Classes {
 
 		$terms = get_the_terms( $post_id, $taxonomy );
 
-		if ( is_wp_error( $terms ) ) {
+		if ( is_wp_error( $terms ) || ! $terms ) {
 			$terms = array();
 		}
 


### PR DESCRIPTION
Undoes https://github.com/devinsays/portfolio-post-type/commit/b0a1538c3ea177cf7fdab650d7404bef4c348076 and fixes it in a better way.
