### PR TITLE
Build term options fixes

### DIFF
--- a/includes/class-portfolio-post-type-admin.php
+++ b/includes/class-portfolio-post-type-admin.php
@@ -152,8 +152,8 @@ class Portfolio_Post_Type_Admin {
 			$options .= sprintf(
 				'<option value="%s"%s />%s</option>',
 				esc_attr( $term->slug ),
-				selected( $current_tax_slug, $term->slug ),
-				esc_html( $term->name . '(' . $term->count . ')' )
+				selected( $current_tax_slug, $term->slug, false ),
+				esc_html( $term->name . ' (' . $term->count . ')' )
 			);
 		}
 		return $options;


### PR DESCRIPTION
Adds a false argument to `selected()` so that it returns not echoes, since it is an argument in a `sprintf()` call.

Also adds a space before the term count, to make it look better.
