### PR TITLE
Add messages for WP 4.4

### DIFF
--- a/includes/class-portfolio-post-type-post-type.php
+++ b/includes/class-portfolio-post-type-post-type.php
@@ -36,20 +36,23 @@ class Portfolio_Post_Type_Post_Type extends Gamajo_Post_Type {
 	 */
 	protected function default_args() {
 		$labels = array(
-			'name'               => __( 'Portfolio', 'portfolio-post-type' ),
-			'singular_name'      => __( 'Portfolio Item', 'portfolio-post-type' ),
-			'menu_name'          => _x( 'Portfolio', 'admin menu', 'portfolio-post-type' ),
-			'name_admin_bar'     => _x( 'Portfolio Item', 'add new on admin bar', 'portfolio-post-type' ),
-			'add_new'            => __( 'Add New Item', 'portfolio-post-type' ),
-			'add_new_item'       => __( 'Add New Portfolio Item', 'portfolio-post-type' ),
-			'new_item'           => __( 'Add New Portfolio Item', 'portfolio-post-type' ),
-			'edit_item'          => __( 'Edit Portfolio Item', 'portfolio-post-type' ),
-			'view_item'          => __( 'View Item', 'portfolio-post-type' ),
-			'all_items'          => __( 'All Portfolio Items', 'portfolio-post-type' ),
-			'search_items'       => __( 'Search Portfolio', 'portfolio-post-type' ),
-			'parent_item_colon'  => __( 'Parent Portfolio Item:', 'portfolio-post-type' ),
-			'not_found'          => __( 'No portfolio items found', 'portfolio-post-type' ),
-			'not_found_in_trash' => __( 'No portfolio items found in trash', 'portfolio-post-type' ),
+			'name'                  => __( 'Portfolio', 'portfolio-post-type' ),
+			'singular_name'         => __( 'Portfolio Item', 'portfolio-post-type' ),
+			'menu_name'             => _x( 'Portfolio', 'admin menu', 'portfolio-post-type' ),
+			'name_admin_bar'        => _x( 'Portfolio Item', 'add new on admin bar', 'portfolio-post-type' ),
+			'add_new'               => __( 'Add New Item', 'portfolio-post-type' ),
+			'add_new_item'          => __( 'Add New Portfolio Item', 'portfolio-post-type' ),
+			'new_item'              => __( 'Add New Portfolio Item', 'portfolio-post-type' ),
+			'edit_item'             => __( 'Edit Portfolio Item', 'portfolio-post-type' ),
+			'view_item'             => __( 'View Item', 'portfolio-post-type' ),
+			'all_items'             => __( 'All Portfolio Items', 'portfolio-post-type' ),
+			'search_items'          => __( 'Search Portfolio', 'portfolio-post-type' ),
+			'parent_item_colon'     => __( 'Parent Portfolio Item:', 'portfolio-post-type' ),
+			'not_found'             => __( 'No portfolio items found', 'portfolio-post-type' ),
+			'not_found_in_trash'    => __( 'No portfolio items found in trash', 'portfolio-post-type' ),
+			'filter_items_list'     => __( 'Filter portfolio items list', 'portfolio-post-type' ),
+			'items_list_navigation' => __( 'Portfolio items list navigation', 'portfolio-post-type' ),
+			'items_list'            => __( 'Portfolio items list', 'portfolio-post-type' ),
 		);
 
 		$supports = array(

--- a/includes/class-portfolio-post-type-taxonomy-category.php
+++ b/includes/class-portfolio-post-type-taxonomy-category.php
@@ -52,6 +52,8 @@ class Portfolio_Post_Type_Taxonomy_Category extends Gamajo_Taxonomy {
 			'add_or_remove_items'        => __( 'Add or remove portfolio categories', 'portfolio-post-type' ),
 			'choose_from_most_used'      => __( 'Choose from the most used portfolio categories', 'portfolio-post-type' ),
 			'not_found'                  => __( 'No portfolio categories found.', 'portfolio-post-type' ),
+			'items_list_navigation'      => __( 'Portfolio categories list navigation', 'portfolio-post-type' ),
+			'items_list'                 => __( 'Portfolio categories list', 'portfolio-post-type' ),
 		);
 
 		$args = array(

--- a/includes/class-portfolio-post-type-taxonomy-tag.php
+++ b/includes/class-portfolio-post-type-taxonomy-tag.php
@@ -52,6 +52,8 @@ class Portfolio_Post_Type_Taxonomy_Tag extends Gamajo_Taxonomy {
 			'add_or_remove_items'        => __( 'Add or remove portfolio tags', 'portfolio-post-type' ),
 			'choose_from_most_used'      => __( 'Choose from the most used portfolio tags', 'portfolio-post-type' ),
 			'not_found'                  => __( 'No portfolio tags found.', 'portfolio-post-type' ),
+			'items_list_navigation'      => __( 'Portfolio tags list navigation', 'portfolio-post-type' ),
+			'items_list'                 => __( 'Portfolio tags list', 'portfolio-post-type' ),
 		);
 
 		$args = array(


### PR DESCRIPTION
The messages are used as headings for screen readers.

See https://make.wordpress.org/core/2015/10/28/headings-hierarchy-changes-in-the-admin-screens/.