### PR TITLE
Fixes 'Array to string conversion' notice in dashboard

### DIFF
--- a/includes/class-gamajo-dashboard-glancer.php
+++ b/includes/class-gamajo-dashboard-glancer.php
@@ -119,7 +119,7 @@ class Gamajo_Dashboard_Glancer {
 	 */
 	protected function get_single_item( array $item ) {
 		$num_posts = wp_count_posts( $item['type'] );
-		$count = $num_posts->$item['status'];
+		$count = $num_posts->{$item['status']};
 
 		if ( ! $count ) {
 			return '';


### PR DESCRIPTION
```
Notice: Array to string conversion in /.../wp-content/plugins/portfolio-post-type/includes/class-gamajo-dashboard-glancer.php on line 122

Notice: Undefined property: stdClass::$Array in /.../wp-content/plugins/portfolio-post-type/includes/class-gamajo-dashboard-glancer.php on line 122

Notice: Array to string conversion in /.../wp-content/plugins/portfolio-post-type/includes/class-gamajo-dashboard-glancer.php on line 122

Notice: Undefined property: stdClass::$Array in /.../wp-content/plugins/portfolio-post-type/includes/class-gamajo-dashboard-glancer.php on line 122
```

http://stackoverflow.com/questions/804850/get-php-class-property-by-string